### PR TITLE
[FIXED JENKINS-11238] M2ReleaseBuildWrapper configuration broken

### DIFF
--- a/src/main/java/org/jvnet/hudson/plugins/m2release/M2ReleaseBuildWrapper.java
+++ b/src/main/java/org/jvnet/hudson/plugins/m2release/M2ReleaseBuildWrapper.java
@@ -94,6 +94,9 @@ public class M2ReleaseBuildWrapper extends BuildWrapper {
 	private transient boolean             appendHusonUserName;
 	private transient String              hudsonUserName;
 
+	/** For backwards compatibility with older configurations. */
+	public transient boolean              defaultVersioningMode;
+
 	public String                         releaseGoals                 = DescriptorImpl.DEFAULT_RELEASE_GOALS;
 	public boolean                        selectCustomScmCommentPrefix = DescriptorImpl.DEFAULT_SELECT_CUSTOM_SCM_COMMENT_PREFIX;
 	public boolean                        selectAppendHudsonUsername   = DescriptorImpl.DEFAULT_SELECT_APPEND_HUDSON_USERNAME;


### PR DESCRIPTION
Add defaultVersioningMode as a transient value to eliminate logspam when
loading job configurations saved using earlier versions of m2release

Tested with a mix of old and new configurations on Jenkins 1.433
