### PR TITLE
Fix typo. "unti" should be "until"

### DIFF
--- a/src/main/java/org/jvnet/hudson/plugins/m2release/M2ReleaseBuildWrapper.java
+++ b/src/main/java/org/jvnet/hudson/plugins/m2release/M2ReleaseBuildWrapper.java
@@ -192,7 +192,7 @@ public class M2ReleaseBuildWrapper extends BuildWrapper {
 
 				if (bld.getResult().isBetterOrEqualTo(Result.SUCCESS)) {
 				    // keep this build.
-				    lstnr.getLogger().println("[M2Release] marking build to keep unti the next release build");
+				    lstnr.getLogger().println("[M2Release] marking build to keep until the next release build");
                     bld.keepLog();
 
 				    for (Run run: (RunList<? extends Run>) (bld.getProject().getBuilds())) {


### PR DESCRIPTION
Correct typo in log message
"[M2Release] marking build to keep unti the next release build"

Note I didn't submit a JIRA ticket for this. It seemed a little excessive for a one character change!
