### PR TITLE
Proposed fix for JENKINS-13465

### DIFF
--- a/src/main/java/org/jvnet/hudson/plugins/m2release/M2ReleaseAction.java
+++ b/src/main/java/org/jvnet/hudson/plugins/m2release/M2ReleaseAction.java
@@ -236,16 +236,18 @@ public class M2ReleaseAction implements PermalinkProjectAction {
 		JSONObject formData = req.getSubmittedForm();
 		JSONArray a = JSONArray.fromObject(formData.get("parameter"));
 		for (Object o : a) {
-			JSONObject jo = (JSONObject) o;
-			if (jo != null && !jo.isNullObject()) {
-				String name = jo.optString("name");
-				if (name != null) {
-					ParameterDefinition d = getParameterDefinition(name);
-					if (d == null) {
-						throw new IllegalArgumentException("No such parameter definition: " + name);
+			if (o instanceof JSONObject) {
+				JSONObject jo = (JSONObject) o;
+				if (jo != null && !jo.isNullObject()) {
+					String name = jo.optString("name");
+					if (name != null) {
+						ParameterDefinition d = getParameterDefinition(name);
+						if (d == null) {
+							throw new IllegalArgumentException("No such parameter definition: " + name);
+						}
+						ParameterValue parameterValue = d.createValue(req, jo);
+						values.add(parameterValue);
 					}
-					ParameterValue parameterValue = d.createValue(req, jo);
-					values.add(parameterValue);
 				}
 			}
 		}


### PR DESCRIPTION
JENKINS-13465 https://issues.jenkins-ci.org/browse/JENKINS-13465

Happened with Jenkins 1.506 and plugin version 0.9.1

I've not found any "parameter" field in the posted form, but not looked very deeply... May be "a" contains only a single JSONNull if formData.get("parameter") is "null" or equivalent.
