### PR TITLE
[FIXED JENKINS-12076] Correctly save parameter

### DIFF
--- a/src/main/java/org/jvnet/hudson/plugins/m2release/M2ReleaseBuildWrapper.java
+++ b/src/main/java/org/jvnet/hudson/plugins/m2release/M2ReleaseBuildWrapper.java
@@ -304,7 +304,7 @@ public class M2ReleaseBuildWrapper extends BuildWrapper {
 		return numberOfReleaseBuildsToKeep;
 	}
 	
-	public void setNumberOfreleaseBuildsToKeep(int numberOfReleaseBuildsToKeep) {
+	public void setNumberOfReleaseBuildsToKeep(int numberOfReleaseBuildsToKeep) {
 		this.numberOfReleaseBuildsToKeep = numberOfReleaseBuildsToKeep;
 	}
 


### PR DESCRIPTION
The build parameter for the number of release builds to keep was not being saved and thus not used.
