### PR TITLE
[FIXED JENKINS-4560] Poms left in a modified state after failed release.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,7 @@
 		<dependency>
 			<groupId>org.jenkins-ci.main</groupId>
 			<artifactId>maven-plugin</artifactId>
+			<version>1.509.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.maven.release</groupId>

--- a/src/main/java/org/jvnet/hudson/plugins/m2release/M2ReleaseBuildWrapper.java
+++ b/src/main/java/org/jvnet/hudson/plugins/m2release/M2ReleaseBuildWrapper.java
@@ -23,7 +23,6 @@
  */
 package org.jvnet.hudson.plugins.m2release;
 
-import com.sun.corba.se.impl.oa.NullServantImpl;
 import hudson.Extension;
 import hudson.Launcher;
 import hudson.Util;

--- a/src/main/java/org/jvnet/hudson/plugins/m2release/M2ReleaseBuildWrapper.java
+++ b/src/main/java/org/jvnet/hudson/plugins/m2release/M2ReleaseBuildWrapper.java
@@ -23,6 +23,7 @@
  */
 package org.jvnet.hudson.plugins.m2release;
 
+import com.sun.corba.se.impl.oa.NullServantImpl;
 import hudson.Extension;
 import hudson.Launcher;
 import hudson.Util;
@@ -45,6 +46,7 @@ import hudson.security.PermissionGroup;
 import hudson.tasks.BuildWrapper;
 import hudson.tasks.BuildWrapperDescriptor;
 import hudson.tasks.Builder;
+import hudson.tasks.Maven;
 import hudson.util.FormValidation;
 import hudson.util.RunList;
 
@@ -95,6 +97,7 @@ public class M2ReleaseBuildWrapper extends BuildWrapper {
 	private String                        scmPasswordEnvVar            = "";
 	private String                        releaseEnvVar                = DescriptorImpl.DEFAULT_RELEASE_ENVVAR;
 	private String                        releaseGoals                 = DescriptorImpl.DEFAULT_RELEASE_GOALS;
+    private String                        rollbackGoals                = DescriptorImpl.DEFAULT_ROLLBACK_GOALS;
 	private String                        dryRunGoals                  = DescriptorImpl.DEFAULT_DRYRUN_GOALS;
 	public boolean                        selectCustomScmCommentPrefix = DescriptorImpl.DEFAULT_SELECT_CUSTOM_SCM_COMMENT_PREFIX;
 	public boolean                        selectAppendHudsonUsername   = DescriptorImpl.DEFAULT_SELECT_APPEND_HUDSON_USERNAME;
@@ -103,9 +106,10 @@ public class M2ReleaseBuildWrapper extends BuildWrapper {
 	public int                            numberOfReleaseBuildsToKeep  = DescriptorImpl.DEFAULT_NUMBER_OF_RELEASE_BUILDS_TO_KEEP;
 	
 	@DataBoundConstructor
-	public M2ReleaseBuildWrapper(String releaseGoals, String dryRunGoals, boolean selectCustomScmCommentPrefix, boolean selectAppendHudsonUsername, boolean selectScmCredentials, String releaseEnvVar, String scmUserEnvVar, String scmPasswordEnvVar, int numberOfReleaseBuildsToKeep) {
+	public M2ReleaseBuildWrapper(String releaseGoals,String rollbackGoals, String dryRunGoals, boolean selectCustomScmCommentPrefix, boolean selectAppendHudsonUsername, boolean selectScmCredentials, String releaseEnvVar, String scmUserEnvVar, String scmPasswordEnvVar, int numberOfReleaseBuildsToKeep) {
 		super();
 		this.releaseGoals = releaseGoals;
+        this.rollbackGoals = rollbackGoals;
 		this.dryRunGoals = dryRunGoals;
 		this.selectCustomScmCommentPrefix = selectCustomScmCommentPrefix;
 		this.selectAppendHudsonUsername = selectAppendHudsonUsername;
@@ -118,7 +122,7 @@ public class M2ReleaseBuildWrapper extends BuildWrapper {
 
 
 	@Override
-	public Environment setUp(@SuppressWarnings("rawtypes") AbstractBuild build, Launcher launcher, final BuildListener listener)
+	public Environment setUp(@SuppressWarnings("rawtypes") final AbstractBuild build, final Launcher launcher, final BuildListener listener)
 	                                                                                              throws IOException,
 	                                                                                              InterruptedException {
 
@@ -186,7 +190,11 @@ public class M2ReleaseBuildWrapper extends BuildWrapper {
 				boolean retVal = true;
 				final MavenModuleSet mmSet = getModuleSet(bld);
 				M2ReleaseArgumentsAction args = bld.getAction(M2ReleaseArgumentsAction.class);
-				
+
+                if (bld.getResult() != Result.SUCCESS) {
+                    executeRollback(bld, lstnr, launcher);
+                }
+
 				if (args.isDryRun()) {
 					lstnr.getLogger().println("[M2Release] its only a dryRun, no need to mark it for keep");
 				}
@@ -265,7 +273,31 @@ public class M2ReleaseBuildWrapper extends BuildWrapper {
 				return retVal;
 			}
 
-			/**
+            private boolean executeRollback(AbstractBuild bld, BuildListener lstnr, Launcher launcher) throws IOException, InterruptedException {
+                boolean isSuccess = false;
+
+                if (Util.fixEmptyAndTrim(rollbackGoals) != null) {
+                    String thisBuildGoals = rollbackGoals;
+
+                    if (scmUserEnvVar != null) {
+                        thisBuildGoals = "-Dusername=" + scmUserEnvVar + " " + thisBuildGoals;
+                    }
+
+                    if (scmPasswordEnvVar != null) {
+                        thisBuildGoals = "-Dpassword=" + scmPasswordEnvVar + " " + thisBuildGoals;
+                    }
+
+                    String mavenName = getModuleSet(bld).getMaven().getName();
+                    Maven buildStep = new Maven(thisBuildGoals, mavenName);
+                    isSuccess = buildStep.prebuild(bld, lstnr);
+                    if (isSuccess) {
+                        isSuccess = buildStep.perform(bld, launcher, lstnr);
+                    }
+                }
+                return isSuccess;
+            }
+
+            /**
 			 * evaluate if the specified build is a sucessful release build (not including dry runs)
 			 * @param run the run to check
 			 * @return <code>true</code> if this is a successful release build that is not a dry run.
@@ -460,6 +492,7 @@ public class M2ReleaseBuildWrapper extends BuildWrapper {
 		}
 
 		public static final String     DEFAULT_RELEASE_GOALS = "-Dresume=false release:prepare release:perform"; //$NON-NLS-1$
+        public static final String     DEFAULT_ROLLBACK_GOALS = "release:rollback";
 		public static final String     DEFAULT_DRYRUN_GOALS = "-Dresume=false -DdryRun=true release:prepare"; //$NON-NLS-1$
 		public static final String     DEFAULT_RELEASE_ENVVAR = "IS_M2RELEASEBUILD"; //$NON-NLS-1$
 		public static final String     DEFAULT_RELEASE_VERSION_ENVVAR = "MVN_RELEASE_VERSION"; //$NON-NLS-1$

--- a/src/main/resources/org/jvnet/hudson/plugins/m2release/M2ReleaseBuildWrapper/config.jelly
+++ b/src/main/resources/org/jvnet/hudson/plugins/m2release/M2ReleaseBuildWrapper/config.jelly
@@ -10,6 +10,11 @@
 		-->
 		<f:textbox field="releaseGoals" value="${h.defaulted(instance.releaseGoals,descriptor.DEFAULT_RELEASE_GOALS)}"/>
 	</f:entry>
+
+    <f:entry title="Rollback goals and options" help="/plugin/m2release/help-projectConfig-rollbackGoals.html">
+        <f:textbox field="rollbackGoals" value="${h.defaulted(instance.rollbackGoals,descriptor.DEFAULT_ROLLBACK_GOALS)}"/>
+    </f:entry>
+
 	<f:entry title="DryRun goals and options" help="/plugin/m2release/help-projectConfig-dryRunGoals.html">
 		<f:textbox field="dryRunGoals" value="${h.defaulted(instance.dryRunGoals,descriptor.DEFAULT_DRYRUN_GOALS)}"/>
 	</f:entry>  

--- a/src/main/webapp/help-projectConfig-rollbackGoals.html
+++ b/src/main/webapp/help-projectConfig-rollbackGoals.html
@@ -1,0 +1,4 @@
+<div>
+    Enter the goals you wish to be invoked if the release process fails (meant for clean up purposes).
+    e.g. <tt>release:rollback</tt>
+</div>

--- a/src/test/java/org/jvnet/hudson/plugins/m2release/M2ReleaseActionTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/m2release/M2ReleaseActionTest.java
@@ -59,7 +59,7 @@ public class M2ReleaseActionTest extends HudsonTestCase {
 		m.setScm(new ExtractResourceSCM(getClass().getResource(projectZip)));
 		m.setGoals("dummygoal"); // build would fail with this goal
 
-		final M2ReleaseBuildWrapper wrapper = new M2ReleaseBuildWrapper(DescriptorImpl.DEFAULT_RELEASE_GOALS, DescriptorImpl.DEFAULT_DRYRUN_GOALS, false,
+		final M2ReleaseBuildWrapper wrapper = new M2ReleaseBuildWrapper(DescriptorImpl.DEFAULT_RELEASE_GOALS, DescriptorImpl.DEFAULT_ROLLBACK_GOALS, DescriptorImpl.DEFAULT_DRYRUN_GOALS, false,
 				false, false, "ENV", "USERENV", "PWDENV", DescriptorImpl.DEFAULT_NUMBER_OF_RELEASE_BUILDS_TO_KEEP);
 		M2ReleaseArgumentsAction args = new M2ReleaseArgumentsAction();
 		args.setDevelopmentVersion("1.0-SNAPSHOT");


### PR DESCRIPTION
This will perform a mvn release:rollback if the Jenkins build is not successful. Credit for the patch goes to stavanets.