### PR TITLE
JENKINS-24090 Re-implement "Append Jenkins Build Number" Option

### DIFF
--- a/src/main/java/org/jvnet/hudson/plugins/m2release/M2ReleaseAction.java
+++ b/src/main/java/org/jvnet/hudson/plugins/m2release/M2ReleaseAction.java
@@ -207,6 +207,7 @@ public class M2ReleaseAction implements PermalinkProjectAction {
 		// good old http...
 		Map<?, ?> httpParams = req.getParameterMap();
 
+		final boolean appendJenkinsBuildNumber = httpParams.containsKey("appendJenkinsBuildNumber"); //$NON-NLS-1$
 		final boolean closeNexusStage = httpParams.containsKey("closeNexusStage"); //$NON-NLS-1$
 		final String repoDescription = closeNexusStage ? getString("repoDescription", httpParams) : ""; //$NON-NLS-1$
 		final boolean specifyScmCredentials = httpParams.containsKey("specifyScmCredentials"); //$NON-NLS-1$
@@ -282,6 +283,7 @@ public class M2ReleaseAction implements PermalinkProjectAction {
 		arguments.setScmCommentPrefix(scmCommentPrefix);
 		arguments.setAppendHusonUserName(appendHusonUserName);
 		arguments.setHudsonUserName(Hudson.getAuthentication().getName());
+		arguments.setAppendJenkinsBuildNumber(appendJenkinsBuildNumber);
 
 		
 		if (project.scheduleBuild(0, new ReleaseCause(), parameters, arguments)) {

--- a/src/main/java/org/jvnet/hudson/plugins/m2release/M2ReleaseAction.java
+++ b/src/main/java/org/jvnet/hudson/plugins/m2release/M2ReleaseAction.java
@@ -71,12 +71,14 @@ public class M2ReleaseAction implements PermalinkProjectAction {
 	private boolean selectCustomScmTag = false;
 	private boolean selectAppendHudsonUsername;
 	private boolean selectScmCredentials;
+	private boolean selectAppendJenkinsBuildNumber;
 
-	public M2ReleaseAction(MavenModuleSet project, boolean selectCustomScmCommentPrefix, boolean selectAppendHudsonUsername, boolean selectScmCredentials) {
+	public M2ReleaseAction(MavenModuleSet project, boolean selectCustomScmCommentPrefix, boolean selectAppendHudsonUsername, boolean selectScmCredentials, boolean selectAppendJenkinsBuildNumber) {
 		this.project = project;
 		this.selectCustomScmCommentPrefix = selectCustomScmCommentPrefix;
 		this.selectAppendHudsonUsername = selectAppendHudsonUsername;
 		this.selectScmCredentials = selectScmCredentials;
+		this.selectAppendJenkinsBuildNumber = selectAppendJenkinsBuildNumber;
 		if (getRootModule() == null) {
 			// if the root module is not available, the user should be informed
 			// about the stuff we are not able to compute
@@ -135,6 +137,14 @@ public class M2ReleaseAction implements PermalinkProjectAction {
 
 	public boolean isSelectCustomScmTag() {
 		return selectCustomScmTag;
+	}
+
+	public boolean isSelectAppendJenkinsBuildNumber() {
+		return selectAppendJenkinsBuildNumber;
+	}
+
+	public void setSelectAppendJenkinsBuildNumber(boolean selectAppendJenkinsBuildNumber) {
+		this.selectAppendJenkinsBuildNumber = selectAppendJenkinsBuildNumber;
 	}
 
 	public Collection<MavenModule> getModules() {

--- a/src/main/java/org/jvnet/hudson/plugins/m2release/M2ReleaseArgumentsAction.java
+++ b/src/main/java/org/jvnet/hudson/plugins/m2release/M2ReleaseArgumentsAction.java
@@ -62,6 +62,7 @@ public class M2ReleaseArgumentsAction implements Action {
 
 	private transient boolean appendHusonUserName;
 	private transient String hudsonUserName;
+	private transient boolean appendJenkinsBuildNumber;
 
 	public M2ReleaseArgumentsAction() {
 		super();
@@ -184,6 +185,14 @@ public class M2ReleaseArgumentsAction implements Action {
 
 	public void setHudsonUserName(String hudsonUserName) {
 		this.hudsonUserName = hudsonUserName;
+	}
+
+	public boolean isAppendJenkinsBuildNumber() {
+		return appendJenkinsBuildNumber;
+	}
+
+	public void setAppendJenkinsBuildNumber(boolean appendJenkinsBuildNumber) {
+		this.appendJenkinsBuildNumber = appendJenkinsBuildNumber;
 	}
 
 }

--- a/src/main/java/org/jvnet/hudson/plugins/m2release/M2ReleaseBuildWrapper.java
+++ b/src/main/java/org/jvnet/hudson/plugins/m2release/M2ReleaseBuildWrapper.java
@@ -99,11 +99,12 @@ public class M2ReleaseBuildWrapper extends BuildWrapper {
 	public boolean                        selectCustomScmCommentPrefix = DescriptorImpl.DEFAULT_SELECT_CUSTOM_SCM_COMMENT_PREFIX;
 	public boolean                        selectAppendHudsonUsername   = DescriptorImpl.DEFAULT_SELECT_APPEND_HUDSON_USERNAME;
 	public boolean                        selectScmCredentials         = DescriptorImpl.DEFAULT_SELECT_SCM_CREDENTIALS;
+	public boolean                        selectAppendJenkinsBuildNumber = DescriptorImpl.DEFAULT_SELECT_APPEND_JENKINS_BUILD_NUMBER;
 	
 	public int                            numberOfReleaseBuildsToKeep  = DescriptorImpl.DEFAULT_NUMBER_OF_RELEASE_BUILDS_TO_KEEP;
 	
 	@DataBoundConstructor
-	public M2ReleaseBuildWrapper(String releaseGoals, String dryRunGoals, boolean selectCustomScmCommentPrefix, boolean selectAppendHudsonUsername, boolean selectScmCredentials, String releaseEnvVar, String scmUserEnvVar, String scmPasswordEnvVar, int numberOfReleaseBuildsToKeep) {
+	public M2ReleaseBuildWrapper(String releaseGoals, String dryRunGoals, boolean selectCustomScmCommentPrefix, boolean selectAppendHudsonUsername, boolean selectScmCredentials, String releaseEnvVar, String scmUserEnvVar, String scmPasswordEnvVar, int numberOfReleaseBuildsToKeep, boolean selectAppendJenkinsBuildNumber) {
 		super();
 		this.releaseGoals = releaseGoals;
 		this.dryRunGoals = dryRunGoals;
@@ -114,6 +115,7 @@ public class M2ReleaseBuildWrapper extends BuildWrapper {
 		this.scmUserEnvVar = scmUserEnvVar;
 		this.scmPasswordEnvVar = scmPasswordEnvVar;
 		this.numberOfReleaseBuildsToKeep = numberOfReleaseBuildsToKeep;
+		this.selectAppendJenkinsBuildNumber = selectAppendJenkinsBuildNumber;
 	}
 
 
@@ -316,6 +318,14 @@ public class M2ReleaseBuildWrapper extends BuildWrapper {
 		this.numberOfReleaseBuildsToKeep = numberOfReleaseBuildsToKeep;
 	}
 
+	public boolean isSelectAppendJenkinsBuildNumber() {
+		return selectAppendJenkinsBuildNumber;
+	}
+
+	public void setSelectAppendJenkinsBuildNumber(boolean selectAppendJenkinsBuildNumber) {
+		this.selectAppendJenkinsBuildNumber = selectAppendJenkinsBuildNumber;
+	}
+
 	private MavenModuleSet getModuleSet(AbstractBuild<?,?> build) {
 		if (build instanceof MavenBuild) {
 			MavenBuild m2Build = (MavenBuild) build;
@@ -381,7 +391,7 @@ public class M2ReleaseBuildWrapper extends BuildWrapper {
 
 	@Override
 	public Action getProjectAction(@SuppressWarnings("rawtypes") AbstractProject job) {
-		return new M2ReleaseAction((MavenModuleSet) job, selectCustomScmCommentPrefix, selectAppendHudsonUsername, selectScmCredentials);
+		return new M2ReleaseAction((MavenModuleSet) job, selectCustomScmCommentPrefix, selectAppendHudsonUsername, selectScmCredentials, selectAppendJenkinsBuildNumber);
 	}
 
 	/**
@@ -473,6 +483,7 @@ public class M2ReleaseBuildWrapper extends BuildWrapper {
 		public static final boolean    DEFAULT_SELECT_CUSTOM_SCM_COMMENT_PREFIX = false;
 		public static final boolean    DEFAULT_SELECT_APPEND_HUDSON_USERNAME    = false;
 		public static final boolean    DEFAULT_SELECT_SCM_CREDENTIALS           = false;
+		public static final boolean    DEFAULT_SELECT_APPEND_JENKINS_BUILD_NUMBER = false;
 
 		public static final int        DEFAULT_NUMBER_OF_RELEASE_BUILDS_TO_KEEP = 1;
 

--- a/src/main/java/org/jvnet/hudson/plugins/m2release/M2ReleaseBuildWrapper.java
+++ b/src/main/java/org/jvnet/hudson/plugins/m2release/M2ReleaseBuildWrapper.java
@@ -141,7 +141,11 @@ public class M2ReleaseBuildWrapper extends BuildWrapper {
 		StringBuilder buildGoals = new StringBuilder();
 
 		buildGoals.append("-DdevelopmentVersion=").append(args.getDevelopmentVersion()).append(' ');
-		buildGoals.append("-DreleaseVersion=").append(args.getReleaseVersion()).append(' ');
+		buildGoals.append("-DreleaseVersion=").append(args.getReleaseVersion());
+		if (args.isAppendJenkinsBuildNumber()) {
+			buildGoals.append('-').append(build.getNumber());
+		}
+		buildGoals.append(' ');
 
 		if (args.getScmUsername() != null) {
 			buildGoals.append("-Dusername=").append(args.getScmUsername()).append(' ');

--- a/src/main/resources/org/jvnet/hudson/plugins/m2release/M2ReleaseAction/index.jelly
+++ b/src/main/resources/org/jvnet/hudson/plugins/m2release/M2ReleaseAction/index.jelly
@@ -14,8 +14,8 @@
 					<f:entry title="Development version">
 						<f:textbox name="developmentVersion" value="${it.computeNextVersion()}" />
 					</f:entry>
-					<f:entry title="Append Jenkins Build Number">
-						<f:checkbox name="appendJenkinsBuildNumber" checked="false"/>
+					<f:entry title="Append Jenkins Build Number" help="/plugin/m2release/help-actionRelease-appendJenkinsBuildNumber.html">
+						<f:checkbox name="appendJenkinsBuildNumber" checked="${it.selectAppendJenkinsBuildNumber}"/>
 					</f:entry>
 					<f:entry title="Dry run only?">
                         <f:checkbox name="isDryRun" checked="false"/>

--- a/src/main/resources/org/jvnet/hudson/plugins/m2release/M2ReleaseAction/index.jelly
+++ b/src/main/resources/org/jvnet/hudson/plugins/m2release/M2ReleaseAction/index.jelly
@@ -14,6 +14,9 @@
 					<f:entry title="Development version">
 						<f:textbox name="developmentVersion" value="${it.computeNextVersion()}" />
 					</f:entry>
+					<f:entry title="Append Jenkins Build Number">
+						<f:checkbox name="appendJenkinsBuildNumber" checked="false"/>
+					</f:entry>
 					<f:entry title="Dry run only?">
                         <f:checkbox name="isDryRun" checked="false"/>
                     </f:entry>

--- a/src/main/resources/org/jvnet/hudson/plugins/m2release/M2ReleaseBuildWrapper/config.jelly
+++ b/src/main/resources/org/jvnet/hudson/plugins/m2release/M2ReleaseBuildWrapper/config.jelly
@@ -26,6 +26,10 @@
 		</select>
 	</f:entry>
 	
+	<f:entry title="Preselect 'Append Jenkins Build Number'" help="/plugin/m2release/help-projectConfig-selectAppendJenkinsBuildNumber.html">
+		<f:checkbox name="selectAppendJenkinsBuildNumber" checked="${h.defaulted(instance.selectAppendJenkinsBuildNumber,descriptor.DEFAULT_SELECT_APPEND_JENKINS_BUILD_NUMBER)}"/>
+	</f:entry>
+	
 	<f:entry title="Preselect 'Specify custom SCM comment prefix'" help="/plugin/m2release/help-projectConfig-selectCustomScmCommentPrefix.html">
 		<f:checkbox name="selectCustomScmCommentPrefix" checked="${h.defaulted(instance.selectCustomScmCommentPrefix,descriptor.DEFAULT_SELECT_CUSTOM_SCM_COMMENT_PREFIX)}"/>
 	</f:entry>

--- a/src/main/webapp/help-actionRelease-appendJenkinsBuildNumber.html
+++ b/src/main/webapp/help-actionRelease-appendJenkinsBuildNumber.html
@@ -1,0 +1,3 @@
+<div>
+	Enable this option to append the Jenkins Build Number to the Release Version Number.
+</div>

--- a/src/main/webapp/help-projectConfig-selectAppendJenkinsBuildNumber.html
+++ b/src/main/webapp/help-projectConfig-selectAppendJenkinsBuildNumber.html
@@ -1,0 +1,3 @@
+<div>
+	Enable this to have the "Append Jenkins Build Number" option (appends the build number to the release version) selected by default in the "Perform Maven Release" view.
+</div>

--- a/src/test/java/org/jvnet/hudson/plugins/m2release/M2ReleaseActionTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/m2release/M2ReleaseActionTest.java
@@ -60,7 +60,8 @@ public class M2ReleaseActionTest extends HudsonTestCase {
 		m.setGoals("dummygoal"); // build would fail with this goal
 
 		final M2ReleaseBuildWrapper wrapper = new M2ReleaseBuildWrapper(DescriptorImpl.DEFAULT_RELEASE_GOALS, DescriptorImpl.DEFAULT_DRYRUN_GOALS, false,
-				false, false, "ENV", "USERENV", "PWDENV", DescriptorImpl.DEFAULT_NUMBER_OF_RELEASE_BUILDS_TO_KEEP);
+				false, false, "ENV", "USERENV", "PWDENV", DescriptorImpl.DEFAULT_NUMBER_OF_RELEASE_BUILDS_TO_KEEP,
+				DescriptorImpl.DEFAULT_SELECT_APPEND_JENKINS_BUILD_NUMBER);
 		M2ReleaseArgumentsAction args = new M2ReleaseArgumentsAction();
 		args.setDevelopmentVersion("1.0-SNAPSHOT");
 		args.setReleaseVersion("0.9");

--- a/src/test/java/org/jvnet/hudson/plugins/m2release/M2ReleaseBadgeActionTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/m2release/M2ReleaseBadgeActionTest.java
@@ -94,7 +94,8 @@ public class M2ReleaseBadgeActionTest extends HudsonTestCase {
 		final M2ReleaseBuildWrapper wrapper =
 				new M2ReleaseBuildWrapper(DescriptorImpl.DEFAULT_RELEASE_GOALS, DescriptorImpl.DEFAULT_DRYRUN_GOALS,
 						false, false, false, "ENV", "USERENV", "PWDENV",
-						DescriptorImpl.DEFAULT_NUMBER_OF_RELEASE_BUILDS_TO_KEEP);
+						DescriptorImpl.DEFAULT_NUMBER_OF_RELEASE_BUILDS_TO_KEEP,
+						DescriptorImpl.DEFAULT_SELECT_APPEND_JENKINS_BUILD_NUMBER);
 		M2ReleaseArgumentsAction args = new M2ReleaseArgumentsAction();
 		args.setReleaseVersion("1.0");
 		args.setDevelopmentVersion("1.1-SNAPSHOT");


### PR DESCRIPTION
We find it very useful to append the Jenkins Build Number to the release version and loosing this feature  when trying to upgrade from an old Hudson version to the latest Jenkins creates issues for us with our current workflow. I have re-implemented this with a couple of improvements.

See https://issues.jenkins-ci.org/browse/JENKINS-24090
