### PR TITLE
add ability to customize the incrementation strategy of the project version number

### DIFF
--- a/src/main/resources/org/jvnet/hudson/plugins/m2release/M2ReleaseBuildWrapper/config.jelly
+++ b/src/main/resources/org/jvnet/hudson/plugins/m2release/M2ReleaseBuildWrapper/config.jelly
@@ -48,5 +48,10 @@
 		<f:entry title="SCM password environment variable" help="/plugin/m2release/help-projectConfig-scmPasswordEnvVar.html">
 			<f:textbox field="scmPasswordEnvVar" value="${instance.scmPasswordEnvVar}"/>
 		</f:entry>
+		<f:optionalBlock name="customVersionNumber" inline="true" title="Enable custom version number format" checked="${h.defaulted(instance.customVersionNumber,descriptor.DEFAULT_SELECT_CUSTOM_VERSION_NUMBER)}" help="/plugin/m2release/help-projectConfig-customVersionNumber.html">
+			<f:entry title="Digit to increment" help="/plugin/m2release/help-projectConfig-customVersionNumberDigit.html">
+				<f:textbox field="customVersionNumberDigit" value="${h.defaulted(instance.customVersionNumberDigit,descriptor.DEFAULT_CUSTOM_VERSION_NUMBER_DIGIT)}" />
+			</f:entry>
+		</f:optionalBlock>
 	</f:advanced>
 </j:jelly>

--- a/src/main/webapp/help-projectConfig-customVersionNumber.html
+++ b/src/main/webapp/help-projectConfig-customVersionNumber.html
@@ -1,0 +1,4 @@
+<div>
+    If checked, you will be able to choose which digit should be incremented during the release phase.
+    For example, in the version number A.B.C.D, the digit 'D' is incremented by default. (Maven default behavior)
+</div>

--- a/src/main/webapp/help-projectConfig-customVersionNumberDigit.html
+++ b/src/main/webapp/help-projectConfig-customVersionNumberDigit.html
@@ -1,0 +1,3 @@
+<div>
+    Indicates which digit should be incremented during the release phase of the project.
+</div>

--- a/src/test/java/org/jvnet/hudson/plugins/m2release/M2ReleaseActionTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/m2release/M2ReleaseActionTest.java
@@ -60,13 +60,14 @@ public class M2ReleaseActionTest extends HudsonTestCase {
 		m.setGoals("dummygoal"); // build would fail with this goal
 
 		final M2ReleaseBuildWrapper wrapper = new M2ReleaseBuildWrapper(DescriptorImpl.DEFAULT_RELEASE_GOALS, DescriptorImpl.DEFAULT_DRYRUN_GOALS, false,
-				false, false, "ENV", "USERENV", "PWDENV", DescriptorImpl.DEFAULT_NUMBER_OF_RELEASE_BUILDS_TO_KEEP);
+				false, false, "ENV", "USERENV", "PWDENV", DescriptorImpl.DEFAULT_NUMBER_OF_RELEASE_BUILDS_TO_KEEP,
+				DescriptorImpl.DEFAULT_SELECT_CUSTOM_VERSION_NUMBER, DescriptorImpl.DEFAULT_CUSTOM_VERSION_NUMBER_DIGIT);
 		M2ReleaseArgumentsAction args = new M2ReleaseArgumentsAction();
 		args.setDevelopmentVersion("1.0-SNAPSHOT");
 		args.setReleaseVersion("0.9");
 		args.setDryRun(true);
 		m.getBuildWrappersList().add(wrapper);
-		
+
 		return assertBuildStatusSuccess(m.scheduleBuild2(0, new ReleaseCause(), args));
 	}
 

--- a/src/test/java/org/jvnet/hudson/plugins/m2release/M2ReleaseBadgeActionTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/m2release/M2ReleaseBadgeActionTest.java
@@ -66,24 +66,24 @@ public class M2ReleaseBadgeActionTest extends HudsonTestCase {
 				runDryRunReleaseWithFailingPostStep("maven3-failing-project.zip", "pom.xml", mavenInstallation, Result.FAILURE);
 		M2ReleaseBadgeAction badge = build.getAction(M2ReleaseBadgeAction.class);
 		assertTrue("Badge should have been marked as failed release", badge.isFailedBuild());
-        assertEquals("1.0", badge.getVersionNumber());
+		assertEquals("1.0", badge.getVersionNumber());
 	}
 
 	private MavenModuleSetBuild runDryRunRelease(String projectZip, String unpackedPom,
-					MavenInstallation mavenInstallation, Result expectedResult)
+												 MavenInstallation mavenInstallation, Result expectedResult)
 			throws Exception {
 		return runDryRunRelease(projectZip, unpackedPom, mavenInstallation, expectedResult, null);
 	}
 
 	private MavenModuleSetBuild runDryRunReleaseWithFailingPostStep(String projectZip, String unpackedPom,
-					MavenInstallation mavenInstallation, Result expectedResult)
+																	MavenInstallation mavenInstallation, Result expectedResult)
 			throws Exception {
 		Builder failingPostStep = new FailingBuilder();
 		return runDryRunRelease(projectZip, unpackedPom, mavenInstallation, expectedResult, failingPostStep);
 	}
 
 	private MavenModuleSetBuild runDryRunRelease(String projectZip, String unpackedPom,
-					MavenInstallation mavenInstallation, Result expectedResult, Builder postStepBuilder)
+												 MavenInstallation mavenInstallation, Result expectedResult, Builder postStepBuilder)
 			throws Exception {
 		MavenModuleSet m = createMavenProject();
 		m.setRootPOM(unpackedPom);
@@ -94,20 +94,21 @@ public class M2ReleaseBadgeActionTest extends HudsonTestCase {
 		final M2ReleaseBuildWrapper wrapper =
 				new M2ReleaseBuildWrapper(DescriptorImpl.DEFAULT_RELEASE_GOALS, DescriptorImpl.DEFAULT_DRYRUN_GOALS,
 						false, false, false, "ENV", "USERENV", "PWDENV",
-						DescriptorImpl.DEFAULT_NUMBER_OF_RELEASE_BUILDS_TO_KEEP);
+						DescriptorImpl.DEFAULT_NUMBER_OF_RELEASE_BUILDS_TO_KEEP,
+						DescriptorImpl.DEFAULT_SELECT_CUSTOM_VERSION_NUMBER, DescriptorImpl.DEFAULT_CUSTOM_VERSION_NUMBER_DIGIT);
 		M2ReleaseArgumentsAction args = new M2ReleaseArgumentsAction();
 		args.setReleaseVersion("1.0");
 		args.setDevelopmentVersion("1.1-SNAPSHOT");
 		args.setDryRun(true);
 		m.getBuildWrappersList().add(wrapper);
-		
+
 		if (postStepBuilder != null) {
 			m.getPostbuilders().add(postStepBuilder);
 		}
-		
+
 		return assertBuildStatus(expectedResult, m.scheduleBuild2(0, new ReleaseCause(), args).get());
 	}
-	
+
 	private static class FailingBuilder extends Builder {
 		@Override
 		public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener)


### PR DESCRIPTION
Add ability to customize the incrementation strategy of the project version number
=======

Why this feature ?
-------

At Sigma Informatique, we use the **m2release-plugin** for many Java projects.
We also have Delphi projects and each are built using Maven.

In Java, our projects' version respects the following scheme : 
**major**.*minor*.patch

In Delphi, we must have 4 digits in our version number :
**major**.*minor*.patch.dummy

> « This version number is composed of 4 parts separated by periods and may include alpha characters » http://en.wikipedia.org/wiki/Microsoft_version_numbering

Maven default versioning strategy auto-increments the last digit of the version number.
As the m2release-plugin relies on Maven's versioning strategy to build the next version number, we are not able to choose which digit should be incremented for our Delphi projects.
The result is that the '*dummy*' digit is always incremented whereas we want the '*patch*' digit to be incremented.  (as it is done for our Java projects...)


----------


How did we implement it ?
-------

In order to enable the user to customize the versioning strategy, I added a configuration option in the "Advanced" box.

![versioning_configuration](https://cloud.githubusercontent.com/assets/2377277/7314374/271dd790-ea64-11e4-83b1-3ce3f5852485.png)

By default, this option is not activated. The user needs to go to the "Advanced" configuration box and to tick the option to enable this new feature.

We understand that we're overriding Maven's default behavior but it is really comfortable to be able to decide the versioning strategy directly within Jenkins.


----------


Please let me know if you have some questions.

Regards,
guillaume
Sigma Informatique