### PR TITLE
JENKINS-15298: Remove defaultVersioningMode until re-implemented

### DIFF
--- a/src/main/resources/org/jvnet/hudson/plugins/m2release/M2ReleaseBuildWrapper/config.jelly
+++ b/src/main/resources/org/jvnet/hudson/plugins/m2release/M2ReleaseBuildWrapper/config.jelly
@@ -17,14 +17,6 @@
 	<f:entry title="Number of successful release builds to keep" help="/plugin/m2release/help-projectConfig-numberOfReleaseBuildsToKeep.html">
 		<f:textbox field="numberOfReleaseBuildsToKeep" value="${h.defaulted(instance.numberOfReleaseBuildsToKeep, descriptor.DEFAULT_NUMBER_OF_RELEASE_BUILDS_TO_KEEP)}" />
 	</f:entry>
-
-	<f:entry title="Default versioning mode" help="/plugin/m2release/help-projectConfig-versioningMode.html">
-		<select name="defaultVersioningMode">
-			<f:option value="${descriptor.VERSIONING_AUTO}" selected="${descriptor.VERSIONING_AUTO == h.defaulted(instance.defaultVersioningMode,descriptor.DEFAULT_VERSIONING)}">None</f:option>
-			<f:option value="${descriptor.VERSIONING_SPECIFY_VERSIONS}" selected="${descriptor.VERSIONING_SPECIFY_VERSIONS == h.defaulted(instance.defaultVersioningMode,descriptor.DEFAULT_VERSIONING)}">Specify version(s)</f:option>
-			<f:option value="${descriptor.VERSIONING_SPECIFY_VERSION}" selected="${descriptor.VERSIONING_SPECIFY_VERSION == h.defaulted(instance.defaultVersioningMode,descriptor.DEFAULT_VERSIONING)}">Specify one version for all modules</f:option>
-		</select>
-	</f:entry>
 	
 	<f:entry title="Preselect 'Specify custom SCM comment prefix'" help="/plugin/m2release/help-projectConfig-selectCustomScmCommentPrefix.html">
 		<f:checkbox name="selectCustomScmCommentPrefix" checked="${h.defaulted(instance.selectCustomScmCommentPrefix,descriptor.DEFAULT_SELECT_CUSTOM_SCM_COMMENT_PREFIX)}"/>


### PR DESCRIPTION
Currently this setting has no effect and is confusing.