### PR TITLE
[JENKINS-40766] add pipeline support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,17 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
+			<groupId>org.jenkins-ci.plugins.workflow</groupId>
+			<artifactId>workflow-step-api</artifactId>
+			<version>2.3</version>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.jenkins-ci.plugins.workflow</groupId>
+			<artifactId>workflow-support</artifactId>
+			<version>2.6</version>
+		</dependency>
+		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
 			<version>1.9.5</version>
@@ -131,6 +142,35 @@
 			<groupId>org.apache.maven</groupId>
 			<artifactId>maven-settings</artifactId>
 			<version>${maven.test.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.jenkins-ci.plugins.workflow</groupId>
+			<artifactId>workflow-step-api</artifactId>
+			<version>2.3</version>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.jenkins-ci.plugins.workflow</groupId>
+			<artifactId>workflow-support</artifactId>
+			<version>2.6</version>
+		</dependency>
+		<dependency>
+			<groupId>org.jenkins-ci.plugins.workflow</groupId>
+			<artifactId>workflow-cps</artifactId>
+			<version>2.9</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.jenkins-ci.plugins.workflow</groupId>
+			<artifactId>workflow-job</artifactId>
+			<version>2.9</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.jenkins-ci.plugins.workflow</groupId>
+			<artifactId>workflow-basic-steps</artifactId>
+			<version>2.1</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>org.jenkins-ci.plugins</groupId>
 		<artifactId>plugin</artifactId>
-		<version>1.509.3</version>
+		<version>2.15</version>
 	</parent>
 
 	<name>Jenkins Maven Release Plug-in Plug-in</name>
@@ -17,9 +17,8 @@
 	<url>http://wiki.jenkins-ci.org/display/JENKINS/M2+Release+Plugin</url>
 
 	<properties>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<maven.test.version>3.0.4</maven.test.version>
+		<jenkins.version>1.642.4</jenkins.version>
 	</properties>
 
 	<developers>
@@ -55,6 +54,7 @@
 		<dependency>
 			<groupId>org.jenkins-ci.main</groupId>
 			<artifactId>maven-plugin</artifactId>
+			<version>2.13</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.maven.release</groupId>
@@ -64,6 +64,10 @@
 				<exclusion>
 					<artifactId>maven-project</artifactId>
 					<groupId>org.apache.maven</groupId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.apache.maven.scm</groupId>
+					<artifactId>maven-scm-providers-standard</artifactId>
 				</exclusion>
 			</exclusions>
 		</dependency>
@@ -91,6 +95,7 @@
 			<version>4.11</version>
 			<scope>test</scope>
 		</dependency>
+<!--
 		<dependency>
 			<groupId>org.apache.maven</groupId>
 			<artifactId>maven-core</artifactId>
@@ -115,6 +120,7 @@
 			<version>${maven.test.version}</version>
 			<scope>test</scope>
 		</dependency>
+-->
 	</dependencies>
 
 	<build>
@@ -129,12 +135,6 @@
 						<exclude>**/apache-maven-*/*</exclude>
 					</excludes>
 				</configuration>
-			</plugin>
-			<plugin>
-				<groupId>org.jenkins-ci.tools</groupId>
-				<artifactId>maven-hpi-plugin</artifactId>
-				<version>1.96</version>
-				<extensions>true</extensions>
 			</plugin>
             <plugin>
               <artifactId>maven-release-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,8 @@
 	<url>http://wiki.jenkins-ci.org/display/JENKINS/M2+Release+Plugin</url>
 
 	<properties>
-		<maven.test.version>3.0.4</maven.test.version>
+		<!-- upd from 3.0.4 to 3.1.0 as MavenExecutionRequest.setTransferListener method is needed by jenkins -->
+		<maven.test.version>3.1.0</maven.test.version>
 		<jenkins.version>1.642.4</jenkins.version>
 	</properties>
 
@@ -95,12 +96,24 @@
 			<version>4.11</version>
 			<scope>test</scope>
 		</dependency>
-<!--
+		<dependency>
+			<groupId>org.jenkins-ci.main</groupId>
+			<artifactId>jenkins-test-harness-tools</artifactId>
+			<version>2.0</version>
+			<scope>test</scope>
+		</dependency>
 		<dependency>
 			<groupId>org.apache.maven</groupId>
 			<artifactId>maven-core</artifactId>
 			<version>${maven.test.version}</version>
 			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<!-- jenkins uses newer version of google guava with changes in api -->
+					<groupId>org.sonatype.sisu</groupId>
+					<artifactId>sisu-guava</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.maven</groupId>
@@ -120,7 +133,6 @@
 			<version>${maven.test.version}</version>
 			<scope>test</scope>
 		</dependency>
--->
 	</dependencies>
 
 	<build>
@@ -139,7 +151,7 @@
             <plugin>
               <artifactId>maven-release-plugin</artifactId>
               <version>2.5</version>
-            </plugin>            
+            </plugin>
 		</plugins>
 	</build>
 

--- a/src/main/java/org/jvnet/hudson/plugins/m2release/LastReleaseListViewColumn.java
+++ b/src/main/java/org/jvnet/hudson/plugins/m2release/LastReleaseListViewColumn.java
@@ -43,6 +43,8 @@ public class LastReleaseListViewColumn extends ListViewColumn {
 
     /**
      * Finds the last release information of the given project.
+     * @param project ref to the maven project
+     * @return release information
      */
     public Info getLastReleaseInfoOf(AbstractMavenProject<?,?> project) {
         Run<?,?> r = LastReleasePermalink.INSTANCE.resolve(project);

--- a/src/main/java/org/jvnet/hudson/plugins/m2release/M2ReleaseAction.java
+++ b/src/main/java/org/jvnet/hudson/plugins/m2release/M2ReleaseAction.java
@@ -295,6 +295,8 @@ public class M2ReleaseAction implements PermalinkProjectAction {
 
 	/**
 	 * Gets the {@link ParameterDefinition} of the given name, if any.
+	 * @param name param's name
+	 * @return parameter definition
 	 */
 	public ParameterDefinition getParameterDefinition(String name) {
 		for (ParameterDefinition pd : getParameterDefinitions()) {

--- a/src/main/java/org/jvnet/hudson/plugins/m2release/M2ReleaseBadgeAction.java
+++ b/src/main/java/org/jvnet/hudson/plugins/m2release/M2ReleaseBadgeAction.java
@@ -98,6 +98,7 @@ public class M2ReleaseBadgeAction implements BuildBadgeAction, RunAction2 {
 
 	/**
 	 * Gets the tooltip text that should be displayed to the user.
+	 * @return release description, e.g. "Release (dryRun) - 1.2.3"
 	 */
 	public String getTooltipText() {
 		StringBuilder str = new StringBuilder();
@@ -118,6 +119,8 @@ public class M2ReleaseBadgeAction implements BuildBadgeAction, RunAction2 {
 
 	/**
 	 * Gets the version number that was released.
+	 *
+	 * @return null if version can't be obtained
 	 */
 	public String getVersionNumber() {
 		if (versionNumber != null) {
@@ -132,7 +135,7 @@ public class M2ReleaseBadgeAction implements BuildBadgeAction, RunAction2 {
 	}
 
 	/**
-	 * Returns if the release was a dryRun or not.
+	 * @return whether the release was a dryRun or not.
 	 */
 	public boolean isDryRun() {
 		if (isDryRun != null) {
@@ -147,7 +150,7 @@ public class M2ReleaseBadgeAction implements BuildBadgeAction, RunAction2 {
 	}
 
 	/**
-	 * Returns <code>true</code> if the release build job failed.
+	 * @return <code>true</code> if the release build job failed.
 	 */
 	public boolean isFailedBuild() {
 		return !isSuccessfulBuild(run);

--- a/src/main/java/org/jvnet/hudson/plugins/m2release/M2ReleaseBuildWrapper.java
+++ b/src/main/java/org/jvnet/hudson/plugins/m2release/M2ReleaseBuildWrapper.java
@@ -365,7 +365,7 @@ public class M2ReleaseBuildWrapper extends BuildWrapper {
 	 * @return <code>true</code> if this build is a release build.
 	 */
 	private boolean isReleaseBuild(@SuppressWarnings("rawtypes") AbstractBuild build) {
-		return (build.getCause(ReleaseCause.class) != null);
+		return build.getCause(ReleaseCause.class) != null;
 	}
 
 

--- a/src/main/java/org/jvnet/hudson/plugins/m2release/M2ReleaseBuildWrapper.java
+++ b/src/main/java/org/jvnet/hudson/plugins/m2release/M2ReleaseBuildWrapper.java
@@ -536,6 +536,13 @@ public class M2ReleaseBuildWrapper extends BuildWrapper {
 
 		/**
 		 * Checks if the Nexus URL exists and we can authenticate against it.
+		 *
+		 * @param urlValue nexus url
+		 * @param usernameValue auth login
+		 * @param passwordValue auth pass
+		 * @throws IOException not used
+		 * @throws ServletException not used
+		 * @return server's response as <code>{@link FormValidation}</code>
 		 */
 		public FormValidation doUrlCheck(@QueryParameter String urlValue, 
 		                                 final @QueryParameter String usernameValue,

--- a/src/main/java/org/jvnet/hudson/plugins/m2release/dashboard/RecentReleasesPortlet.java
+++ b/src/main/java/org/jvnet/hudson/plugins/m2release/dashboard/RecentReleasesPortlet.java
@@ -46,7 +46,7 @@ public class RecentReleasesPortlet extends DashboardPortlet {
      * Get the release version from this run
      *
      * @param run Must be a release run - i.e. have a ReleaseBuildBadgeAction
-     * @return
+     * @return result of <code>{@link M2ReleaseBadgeAction#getVersionNumber()}</code>
      */
     public String getReleaseVersion(Run run) {
         M2ReleaseBadgeAction rbb = run.getAction(M2ReleaseBadgeAction.class);

--- a/src/main/java/org/jvnet/hudson/plugins/m2release/nexus/StageClient.java
+++ b/src/main/java/org/jvnet/hudson/plugins/m2release/nexus/StageClient.java
@@ -103,8 +103,8 @@ public class StageClient {
 	/**
 	 * Get the ID for the Staging repository that holds the specified GAV.
 	 * 
-	 * @param groupId groupID to search for.
-	 * @param artifactId artifactID to search for.
+	 * @param group groupID to search for.
+	 * @param artifact artifactID to search for.
 	 * @param version version of the group/artifact to search for - may be <code>null</code>.
 	 * @return the stageID or null if no machine stage was found.
 	 * @throws StageException if any issue occurred whilst locating the open stage.
@@ -134,6 +134,7 @@ public class StageClient {
 	 * Close the specified stage.
 	 * 
 	 * @param stage the stage to close.
+	 * @param description description to pass to the server for the action
 	 * @throws StageException if any issue occurred whilst closing the stage.
 	 */
 	public void closeStage(Stage stage, String description) throws StageException {
@@ -225,7 +226,7 @@ public class StageClient {
 	 * Completion of the stage action is asynchronous - so poll until the action completed.
 	 * 
 	 * @param stage the stage to wait until the previous action is completed.
-	 * @throws StageException
+	 * @throws StageException a wrap for Thread.sleep
 	 */
 	protected void waitForActionToComplete(Stage stage) throws StageException {
 		log.debug("Waiting for {} to finish transitioning.", stage);
@@ -259,7 +260,6 @@ public class StageClient {
 	/**
 	 * Check if we have the required permissions for nexus staging.
 	 * 
-	 * @return
 	 * @throws StageException if an exception occurred whilst checking the authorisation.
 	 */
 	public void checkAuthentication() throws StageException {
@@ -324,7 +324,6 @@ public class StageClient {
 	/**
 	 * Checks if this Nexus server uses asynchronous stage actions.
 	 * 
-	 * @param version the version of this server
 	 * @return true if this server uses asynchronous stage actions (i.e. the server is 2.4 or newer).
 	 * @throws StageException if we could not retreive the server version.
 	 */
@@ -371,7 +370,7 @@ public class StageClient {
 	 * 
 	 * @param doc the stagingRepositories to parse.
 	 * @return a List of open stages.
-	 * @throws XPathException if the XPath expression is invalid.
+	 * @throws StageException if the XPath expression is invalid.
 	 */
 	protected List<Stage> getOpenStageIDs(Document doc) throws StageException {
 		List<Stage> stages = new ArrayList<Stage>();

--- a/src/main/java/org/jvnet/hudson/plugins/m2release/pipeline/M2ReleaseQueueListener.java
+++ b/src/main/java/org/jvnet/hudson/plugins/m2release/pipeline/M2ReleaseQueueListener.java
@@ -1,0 +1,23 @@
+package org.jvnet.hudson.plugins.m2release.pipeline;
+
+import hudson.AbortException;
+import hudson.Extension;
+import hudson.model.Queue;
+import hudson.model.queue.QueueListener;
+
+/**
+ * copied from org.jenkinsci.plugins.workflow.support.steps.build.BuildQueueListener
+ */
+@Extension
+public class M2ReleaseQueueListener extends QueueListener {
+    @Override
+    public void onLeft(Queue.LeftItem li) {
+        if(li.isCancelled()){
+            for (M2ReleaseTriggerAction.Trigger trigger : M2ReleaseTriggerAction.triggersFor(li)) {
+                trigger.context.onFailure(new AbortException("Build of " + li.task.getFullDisplayName() + " was cancelled"));
+            }
+        }
+    }
+
+
+}

--- a/src/main/java/org/jvnet/hudson/plugins/m2release/pipeline/M2ReleaseStep.java
+++ b/src/main/java/org/jvnet/hudson/plugins/m2release/pipeline/M2ReleaseStep.java
@@ -1,0 +1,181 @@
+package org.jvnet.hudson.plugins.m2release.pipeline;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Logger;
+
+import javax.annotation.Nonnull;
+
+import org.apache.commons.lang.StringUtils;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepExecutionImpl;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
+import org.jenkinsci.plugins.workflow.steps.StepContextParameter;
+import org.jenkinsci.plugins.workflow.util.StaplerReferer;
+import org.jvnet.hudson.plugins.m2release.M2ReleaseAction;
+import org.jvnet.hudson.plugins.m2release.M2ReleaseArgumentsAction;
+import org.jvnet.hudson.plugins.m2release.ReleaseCause;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.DoNotUse;
+import org.kohsuke.stapler.AncestorInPath;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+import org.kohsuke.stapler.QueryParameter;
+
+import com.google.inject.Inject;
+
+import hudson.AbortException;
+import hudson.Extension;
+import hudson.console.ModelHyperlinkNote;
+import hudson.maven.MavenModuleSet;
+import hudson.model.AbstractProject;
+import hudson.model.Action;
+import hudson.model.AutoCompletionCandidates;
+import hudson.model.Cause;
+import hudson.model.CauseAction;
+import hudson.model.Hudson;
+import hudson.model.ItemGroup;
+import hudson.model.Job;
+import hudson.model.ParameterValue;
+import hudson.model.ParametersAction;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.model.queue.QueueTaskFuture;
+import jenkins.model.Jenkins;
+import jenkins.model.ParameterizedJobMixIn;
+
+/**
+ * Created by e3cmea on 1/3/17.
+ *
+ * @author Alexey Merezhin
+ */
+public class M2ReleaseStep extends AbstractStepImpl {
+    private static final Logger LOGGER = Logger.getLogger(M2ReleaseStep.class.getName());
+
+    private String job;
+    private String releaseVersion = "";
+    private String developmentVersion = "";
+    private Boolean isDryRun = false;
+
+    @DataBoundConstructor
+    public M2ReleaseStep(String job) {
+        this.job = job;
+    }
+
+    public String getJob() {
+        return job;
+    }
+
+    public void setJob(String job) {
+        this.job = job;
+    }
+
+    public String getReleaseVersion() {
+        return releaseVersion;
+    }
+
+    @DataBoundSetter public void setReleaseVersion(String releaseVersion) {
+        this.releaseVersion = releaseVersion;
+    }
+
+    public String getDevelopmentVersion() {
+        return developmentVersion;
+    }
+
+    @DataBoundSetter public void setDevelopmentVersion(String developmentVersion) {
+        this.developmentVersion = developmentVersion;
+    }
+
+    public Boolean isDryRun() {
+        return isDryRun;
+    }
+
+    @DataBoundSetter public void setDryRun(Boolean dryRun) {
+        isDryRun = dryRun;
+    }
+
+    public static class Execution extends AbstractStepExecutionImpl {
+        @StepContextParameter private transient Run<?,?> invokingRun;
+        @StepContextParameter private transient TaskListener listener;
+
+        @Inject(optional=true) transient M2ReleaseStep step;
+
+        @Override
+        public boolean start() throws Exception {
+            if (step.getJob() == null) {
+                throw new AbortException("Job name is not defined.");
+            }
+
+            final MavenModuleSet project = Jenkins.getActiveInstance()
+                                                  .getItem(step.getJob(), invokingRun.getParent(), MavenModuleSet.class);
+            if (project == null) {
+                throw new AbortException("No parametrized job named " + step.getJob() + " found");
+            }
+            listener.getLogger().println("Releasing project: " + ModelHyperlinkNote.encodeTo(project));
+
+            List<ParameterValue> values = new ArrayList<>();
+
+            // schedule release build
+            ParametersAction parameters = new ParametersAction(values);
+
+            M2ReleaseArgumentsAction arguments = new M2ReleaseArgumentsAction();
+            M2ReleaseAction releaseAction = new M2ReleaseAction(project, false, false, false);
+            arguments.setDryRun(step.isDryRun());
+            arguments.setReleaseVersion(step.getReleaseVersion());
+            if (StringUtils.isBlank(arguments.getReleaseVersion())) {
+                arguments.setReleaseVersion(releaseAction.computeReleaseVersion());
+            }
+            arguments.setDevelopmentVersion(step.getDevelopmentVersion());
+            if (StringUtils.isBlank(arguments.getDevelopmentVersion())) {
+                arguments.setDevelopmentVersion(releaseAction.computeNextVersion());
+            }
+
+            List<Action> actions = new ArrayList<>();
+            actions.add(new M2ReleaseTriggerAction(getContext()));
+            actions.add(parameters);
+            actions.add(arguments);
+            actions.add(new CauseAction(new ReleaseCause()));
+
+            QueueTaskFuture<?> task = project.scheduleBuild2(0, new Cause.UpstreamCause(invokingRun), actions);
+            if (task == null) {
+                throw new AbortException("Failed to trigger build of " + project.getFullName());
+            }
+
+            return false;
+        }
+
+        @Override
+        public void stop(@Nonnull Throwable cause) throws Exception {
+            getContext().onFailure(cause);
+        }
+
+        private static final long serialVersionUID = 1L;
+    }
+
+    @Extension
+    public static class DescriptorImpl extends AbstractStepDescriptorImpl {
+        public DescriptorImpl() {
+            super(Execution.class);
+        }
+
+        @Override
+        public String getFunctionName() {
+            return "m2release";
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "Trigger M2 release for the job";
+        }
+
+        public AutoCompletionCandidates doAutoCompleteJob(@AncestorInPath ItemGroup<?> context, @QueryParameter String value) {
+            return AutoCompletionCandidates.ofJobNames(ParameterizedJobMixIn.ParameterizedJob.class, value, context);
+        }
+
+        @Restricted(DoNotUse.class) // for use from config.jelly
+        public String getContext() {
+            Job<?,?> job = StaplerReferer.findItemFromRequest(Job.class);
+            return job != null ? job.getFullName() : null;
+        }
+    }
+}

--- a/src/main/java/org/jvnet/hudson/plugins/m2release/pipeline/M2ReleaseTriggerAction.java
+++ b/src/main/java/org/jvnet/hudson/plugins/m2release/pipeline/M2ReleaseTriggerAction.java
@@ -1,0 +1,83 @@
+package org.jvnet.hudson.plugins.m2release.pipeline;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.annotation.CheckForNull;
+
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+
+import hudson.model.Action;
+import hudson.model.Actionable;
+import hudson.model.InvisibleAction;
+import hudson.model.Queue;
+import hudson.model.queue.FoldableAction;
+
+/**
+ * copied from org.jenkinsci.plugins.workflow.support.steps.build.BuildTriggerAction
+ */
+@SuppressWarnings("SynchronizeOnNonFinalField")
+class M2ReleaseTriggerAction extends InvisibleAction implements FoldableAction {
+
+    private static final Logger LOGGER = Logger.getLogger(M2ReleaseTriggerAction.class.getName());
+
+    @Deprecated
+    private StepContext context;
+
+    /** Record of one upstream build step. */
+    static class Trigger {
+
+        final StepContext context;
+
+
+        /** Record of cancellation cause passed to {@link M2ReleaseStep$Execution#stop}, if any. */
+        @CheckForNull Throwable interruption;
+
+        Trigger(StepContext context) {
+            this.context = context;
+        }
+
+    }
+
+    private /* final */ List<Trigger> triggers;
+
+    M2ReleaseTriggerAction(StepContext context) {
+        triggers = new ArrayList<>();
+        triggers.add(new Trigger(context));
+    }
+
+    private Object readResolve() {
+        if (triggers == null) {
+            triggers = new ArrayList<>();
+            triggers.add(new Trigger(context));
+            context = null;
+        }
+        return this;
+    }
+
+    static Iterable<Trigger> triggersFor(Actionable actionable) {
+        List<Trigger> triggers = new ArrayList<>();
+        for (M2ReleaseTriggerAction action : actionable.getActions(M2ReleaseTriggerAction.class)) {
+            synchronized (action.triggers) {
+                triggers.addAll(action.triggers);
+            }
+        }
+        return triggers;
+    }
+
+    @Override public void foldIntoExisting(Queue.Item item, Queue.Task owner, List<Action> otherActions) {
+        // there may be >1 upstream builds (or other unrelated causes) for a single downstream build
+        M2ReleaseTriggerAction existing = item.getAction(M2ReleaseTriggerAction.class);
+        if (existing == null) {
+            item.addAction(this);
+        } else {
+            synchronized (existing.triggers) {
+                existing.triggers.addAll(triggers);
+            }
+        }
+        LOGGER.log(Level.FINE, "coalescing actions for {0}", item);
+    }
+
+}

--- a/src/main/java/org/jvnet/hudson/plugins/m2release/pipeline/M2ReleaseTriggerListener.java
+++ b/src/main/java/org/jvnet/hudson/plugins/m2release/pipeline/M2ReleaseTriggerListener.java
@@ -1,0 +1,72 @@
+package org.jvnet.hudson.plugins.m2release.pipeline;
+
+import static java.util.logging.Level.WARNING;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.annotation.Nonnull;
+
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.jenkinsci.plugins.workflow.support.steps.build.RunWrapper;
+
+import hudson.AbortException;
+import hudson.Extension;
+import hudson.console.ModelHyperlinkNote;
+import hudson.model.Result;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.model.listeners.RunListener;
+
+/**
+ * copied from org.jenkinsci.plugins.workflow.support.steps.build.BuildTriggerListener
+ */
+@Extension
+public class M2ReleaseTriggerListener extends RunListener<Run<?,?>>{
+
+    private static final Logger LOGGER = Logger.getLogger(M2ReleaseTriggerListener.class.getName());
+
+    @Override
+    public void onStarted(Run<?, ?> run, TaskListener listener) {
+        for (M2ReleaseTriggerAction.Trigger trigger : M2ReleaseTriggerAction.triggersFor(run)) {
+            StepContext stepContext = trigger.context;
+            if (stepContext != null && stepContext.isReady()) {
+                LOGGER.log(Level.FINE, "started releasing {0} from #{1} in {2}", new Object[] {run, run.getQueueId(), stepContext});
+                try {
+                    TaskListener taskListener = stepContext.get(TaskListener.class);
+                    // encodeTo(Run) calls getDisplayName, which does not include the project name.
+                    taskListener.getLogger().println("Starting releasing: " + ModelHyperlinkNote.encodeTo("/" + run.getUrl(), run.getFullDisplayName()));
+                } catch (Exception e) {
+                    LOGGER.log(WARNING, null, e);
+                }
+            } else {
+                LOGGER.log(Level.FINE, "{0} unavailable in {1}", new Object[] {stepContext, run});
+            }
+        }
+    }
+
+    @Override
+    @SuppressWarnings("deprecation") // TODO 2.30+ use removeAction
+    public void onCompleted(Run<?,?> run, @Nonnull TaskListener listener) {
+        for (M2ReleaseTriggerAction.Trigger trigger : M2ReleaseTriggerAction.triggersFor(run)) {
+            LOGGER.log(Level.FINE, "completing {0} for {1}", new Object[] {run, trigger.context});
+            if (run.getResult() == Result.SUCCESS) {
+                if (trigger.interruption == null) {
+                    trigger.context.onSuccess(new RunWrapper(run, false));
+                } else {
+                    trigger.context.onFailure(trigger.interruption);
+                }
+            } else {
+                trigger.context.onFailure(new AbortException(run.getFullDisplayName() + " completed with status " + run.getResult()));
+            }
+        }
+        run.getActions().removeAll(run.getActions(M2ReleaseTriggerAction.class));
+    }
+
+    @Override
+    public void onDeleted(Run<?,?> run) {
+        for (M2ReleaseTriggerAction.Trigger trigger : M2ReleaseTriggerAction.triggersFor(run)) {
+            trigger.context.onFailure(new AbortException(run.getFullDisplayName() + " was deleted"));
+        }
+    }
+}

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -3,6 +3,7 @@
 
   Since we don't really have anything dynamic here, let's just use static HTML. 
 -->
+<?jelly escape-by-default='true'?>
 <div>
   A plug-in that enables you to perform releases using the <a href="http://maven.apache.org/plugins/maven-release-plugin/">maven-release-plugin</a> from Jenkins.
 </div>

--- a/src/main/resources/org/jvnet/hudson/plugins/m2release/LastReleaseListViewColumn/column.jelly
+++ b/src/main/resources/org/jvnet/hudson/plugins/m2release/LastReleaseListViewColumn/column.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <j:set var="info" value="${it.getLastReleaseInfoOf(job)}" />

--- a/src/main/resources/org/jvnet/hudson/plugins/m2release/LastReleaseListViewColumn/columnHeader.jelly
+++ b/src/main/resources/org/jvnet/hudson/plugins/m2release/LastReleaseListViewColumn/columnHeader.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core">
     <th>${%Last Release}</th>
 </j:jelly>

--- a/src/main/resources/org/jvnet/hudson/plugins/m2release/M2ReleaseAction/failed.jelly
+++ b/src/main/resources/org/jvnet/hudson/plugins/m2release/M2ReleaseAction/failed.jelly
@@ -1,6 +1,7 @@
 <!--
 	The user tried to schedule a build but it failed.
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 	<l:layout>
 		<l:main-panel>

--- a/src/main/resources/org/jvnet/hudson/plugins/m2release/M2ReleaseAction/index.jelly
+++ b/src/main/resources/org/jvnet/hudson/plugins/m2release/M2ReleaseAction/index.jelly
@@ -3,6 +3,7 @@
 
 	This belongs to a build view.
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 	<l:layout norefresh="true">
 		<l:main-panel>

--- a/src/main/resources/org/jvnet/hudson/plugins/m2release/M2ReleaseBadgeAction/badge.jelly
+++ b/src/main/resources/org/jvnet/hudson/plugins/m2release/M2ReleaseBadgeAction/badge.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core">
     <j:choose>
         <j:when test="${it.isFailedBuild()}">

--- a/src/main/resources/org/jvnet/hudson/plugins/m2release/M2ReleaseBuildWrapper/config.jelly
+++ b/src/main/resources/org/jvnet/hudson/plugins/m2release/M2ReleaseBuildWrapper/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 	<!--
 		This jelly script is used for per-project configuration.

--- a/src/main/resources/org/jvnet/hudson/plugins/m2release/M2ReleaseBuildWrapper/global.jelly
+++ b/src/main/resources/org/jvnet/hudson/plugins/m2release/M2ReleaseBuildWrapper/global.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 	<!--
 		This Jelly script is used to produce the global configuration option.

--- a/src/main/resources/org/jvnet/hudson/plugins/m2release/ReleaseCause/description.jelly
+++ b/src/main/resources/org/jvnet/hudson/plugins/m2release/ReleaseCause/description.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 	<p>${%releasedBy(it.userName,rootURL)}</p>
 </j:jelly>

--- a/src/main/resources/org/jvnet/hudson/plugins/m2release/dashboard/RecentReleasesPortlet/config.jelly
+++ b/src/main/resources/org/jvnet/hudson/plugins/m2release/dashboard/RecentReleasesPortlet/config.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:entry title="${%Name}">
     <f:textbox name="portlet.name" field="name"/>

--- a/src/main/resources/org/jvnet/hudson/plugins/m2release/dashboard/RecentReleasesPortlet/main.jelly
+++ b/src/main/resources/org/jvnet/hudson/plugins/m2release/dashboard/RecentReleasesPortlet/main.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:dp="/hudson/plugins/view/dashboard" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <table class="sortable pane bigtable" id="projectStatus">
   <tr><td class="pane-header" colspan="5">${it.displayName}</td></tr>

--- a/src/main/resources/org/jvnet/hudson/plugins/m2release/dashboard/RecentReleasesPortlet/portlet.jelly
+++ b/src/main/resources/org/jvnet/hudson/plugins/m2release/dashboard/RecentReleasesPortlet/portlet.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:dp="/hudson/plugins/view/dashboard" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <dp:decorate portlet="${it}" width="2">
   <j:set var="recentReleases" value="${it.getRecentReleases(5)}"/>

--- a/src/main/resources/org/jvnet/hudson/plugins/m2release/pipeline/M2ReleaseStep/config.jelly
+++ b/src/main/resources/org/jvnet/hudson/plugins/m2release/pipeline/M2ReleaseStep/config.jelly
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+The MIT License
+
+Copyright (c) 2016 Steven G. Brown
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:st="jelly:stapler">
+    <j:set var="jobFieldId" value="${h.generateId()}"/>
+    <f:entry field="job" title="Project to Release">
+        <f:textbox id="${jobFieldId}"/>
+    </f:entry>
+    <f:entry field="releaseVersion" title="Release version">
+        <f:textbox/>
+    </f:entry>
+    <f:entry field="developmentVersion" title="Development (after release) version">
+        <f:textbox/>
+    </f:entry>
+    <f:entry field="dryRun" title="Dry run?">
+        <f:checkbox/>
+    </f:entry>
+</j:jelly>

--- a/src/test/java/org/jvnet/hudson/plugins/m2release/M2ReleaseActionTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/m2release/M2ReleaseActionTest.java
@@ -23,29 +23,40 @@
  */
 package org.jvnet.hudson.plugins.m2release;
 
+import static junit.framework.TestCase.assertFalse;
+import static junit.framework.TestCase.assertTrue;
+import static org.jvnet.hudson.test.ToolInstallations.configureDefaultMaven;
+import static org.jvnet.hudson.test.ToolInstallations.configureMaven3;
+
 import hudson.maven.MavenUtil;
 import hudson.maven.MavenModuleSet;
 import hudson.maven.MavenModuleSetBuild;
 import hudson.tasks.Maven.MavenInstallation;
 
+import org.junit.Rule;
+import org.junit.Test;
 import org.jvnet.hudson.plugins.m2release.M2ReleaseBuildWrapper.DescriptorImpl;
 import org.jvnet.hudson.test.ExtractResourceSCM;
-import org.jvnet.hudson.test.HudsonTestCase;
+import org.jvnet.hudson.test.JenkinsRule;
 
-public class M2ReleaseActionTest extends HudsonTestCase {
+public class M2ReleaseActionTest {
+	@Rule public JenkinsRule j = new JenkinsRule();
 
+	@Test
 	public void testPrepareRelease_dryRun_m3() throws Exception {
 		MavenInstallation mavenInstallation = configureMaven3();
 		final MavenModuleSetBuild build = this.runPepareRelease_dryRun("maven3-project.zip", "maven3-project/pom.xml", mavenInstallation);
 		assertTrue("should have been run with maven 3", MavenUtil.maven3orLater(build.getMavenVersionUsed()));
 	}
 
+	@Test
 	public void testPrepareRelease_dryRun_m2project_with_m3() throws Exception {
 		MavenInstallation mavenInstallation = configureMaven3();
 		final MavenModuleSetBuild build = this.runPepareRelease_dryRun("maven2-project.zip", "pom.xml", mavenInstallation);
 		assertTrue("should have been run with maven 3", MavenUtil.maven3orLater(build.getMavenVersionUsed()));
 	}
 
+	@Test
 	public void testPrepareRelease_dryRun_m2project_with_m2() throws Exception {
 		MavenInstallation mavenInstallation = configureDefaultMaven();
 		final MavenModuleSetBuild build = this.runPepareRelease_dryRun("maven2-project.zip", "pom.xml", mavenInstallation);
@@ -53,7 +64,7 @@ public class M2ReleaseActionTest extends HudsonTestCase {
 	}
 
 	public MavenModuleSetBuild runPepareRelease_dryRun(String projectZip, String unpackedPom, MavenInstallation mavenInstallation) throws Exception {
-		MavenModuleSet m = createMavenProject();
+		MavenModuleSet m = j.createProject(MavenModuleSet.class);
 		m.setRootPOM(unpackedPom);
 		m.setMaven(mavenInstallation.getName());
 		m.setScm(new ExtractResourceSCM(getClass().getResource(projectZip)));
@@ -66,8 +77,8 @@ public class M2ReleaseActionTest extends HudsonTestCase {
 		args.setReleaseVersion("0.9");
 		args.setDryRun(true);
 		m.getBuildWrappersList().add(wrapper);
-		
-		return assertBuildStatusSuccess(m.scheduleBuild2(0, new ReleaseCause(), args));
+
+		return j.assertBuildStatusSuccess(m.scheduleBuild2(0, new ReleaseCause(), args));
 	}
 
 }

--- a/src/test/java/org/jvnet/hudson/plugins/m2release/M2ReleaseBadgeActionTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/m2release/M2ReleaseBadgeActionTest.java
@@ -23,6 +23,12 @@
  */
 package org.jvnet.hudson.plugins.m2release;
 
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertFalse;
+import static junit.framework.TestCase.assertTrue;
+import static org.jvnet.hudson.test.ToolInstallations.configureDefaultMaven;
+import static org.jvnet.hudson.test.ToolInstallations.configureMaven3;
+
 import java.io.IOException;
 
 import hudson.Launcher;
@@ -34,12 +40,16 @@ import hudson.model.AbstractBuild;
 import hudson.tasks.Builder;
 import hudson.tasks.Maven.MavenInstallation;
 
+import org.junit.Rule;
+import org.junit.Test;
 import org.jvnet.hudson.plugins.m2release.M2ReleaseBuildWrapper.DescriptorImpl;
 import org.jvnet.hudson.test.ExtractResourceSCM;
-import org.jvnet.hudson.test.HudsonTestCase;
+import org.jvnet.hudson.test.JenkinsRule;
 
-public class M2ReleaseBadgeActionTest extends HudsonTestCase {
+public class M2ReleaseBadgeActionTest {
+	@Rule public JenkinsRule j = new JenkinsRule();
 
+	@Test
 	public void testBadgeForSuccessfulDryRunRelease() throws Exception {
 		MavenInstallation mavenInstallation = configureDefaultMaven();
 		final MavenModuleSetBuild build =
@@ -50,6 +60,7 @@ public class M2ReleaseBadgeActionTest extends HudsonTestCase {
 		assertEquals("1.0", badge.getVersionNumber());
 	}
 
+	@Test
 	public void testBadgeForFailedDryRunRelease() throws Exception {
 		MavenInstallation mavenInstallation = configureMaven3();
 		final MavenModuleSetBuild build =
@@ -60,6 +71,7 @@ public class M2ReleaseBadgeActionTest extends HudsonTestCase {
 		assertEquals("1.0", badge.getVersionNumber());
 	}
 
+	@Test
 	public void testBadgeForFailedPostBuildStepRelease() throws Exception {
 		MavenInstallation mavenInstallation = configureMaven3();
 		final MavenModuleSetBuild build =
@@ -85,7 +97,7 @@ public class M2ReleaseBadgeActionTest extends HudsonTestCase {
 	private MavenModuleSetBuild runDryRunRelease(String projectZip, String unpackedPom,
 					MavenInstallation mavenInstallation, Result expectedResult, Builder postStepBuilder)
 			throws Exception {
-		MavenModuleSet m = createMavenProject();
+		MavenModuleSet m = j.createProject(MavenModuleSet.class);
 		m.setRootPOM(unpackedPom);
 		m.setMaven(mavenInstallation.getName());
 		m.setScm(new ExtractResourceSCM(getClass().getResource(projectZip)));
@@ -105,7 +117,7 @@ public class M2ReleaseBadgeActionTest extends HudsonTestCase {
 			m.getPostbuilders().add(postStepBuilder);
 		}
 		
-		return assertBuildStatus(expectedResult, m.scheduleBuild2(0, new ReleaseCause(), args).get());
+		return j.assertBuildStatus(expectedResult, m.scheduleBuild2(0, new ReleaseCause(), args).get());
 	}
 	
 	private static class FailingBuilder extends Builder {

--- a/src/test/java/org/jvnet/hudson/plugins/m2release/pipeline/M2ReleaseStepTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/m2release/pipeline/M2ReleaseStepTest.java
@@ -1,0 +1,85 @@
+package org.jvnet.hudson.plugins.m2release.pipeline;
+
+import static org.jvnet.hudson.test.ToolInstallations.configureMaven3;
+
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.plugins.m2release.M2ReleaseActionTest;
+import org.jvnet.hudson.plugins.m2release.M2ReleaseBuildWrapper;
+import org.jvnet.hudson.test.BuildWatcher;
+import org.jvnet.hudson.test.ExtractResourceSCM;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.LoggerRule;
+
+import hudson.maven.MavenModuleSet;
+import hudson.model.Action;
+import hudson.model.Job;
+import hudson.model.queue.QueueTaskFuture;
+import jenkins.model.ParameterizedJobMixIn;
+
+/**
+ * @author Alexey Merezhin
+ */
+public class M2ReleaseStepTest {
+    @ClassRule
+    public static BuildWatcher buildWatcher = new BuildWatcher();
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+    @Rule public LoggerRule logging = new LoggerRule();
+    private MavenModuleSet ds;
+
+    @Before
+    public void setUp() throws Exception {
+        ds = j.createProject(MavenModuleSet.class, "ds");
+        ds.setRootPOM("maven3-project/pom.xml");
+        ds.setMaven(configureMaven3().getName());
+        ds.setScm(new ExtractResourceSCM(M2ReleaseActionTest.class.getResource("maven3-project.zip")));
+        ds.setGoals("compile"); // build would fail with this goal
+
+        M2ReleaseBuildWrapper wrapper = new M2ReleaseBuildWrapper(
+                M2ReleaseBuildWrapper.DescriptorImpl.DEFAULT_RELEASE_GOALS, M2ReleaseBuildWrapper.DescriptorImpl.DEFAULT_DRYRUN_GOALS, false,
+                false, false, "ENV", "USERENV", "PWDENV", M2ReleaseBuildWrapper.DescriptorImpl.DEFAULT_NUMBER_OF_RELEASE_BUILDS_TO_KEEP);
+        ds.getBuildWrappersList().add(wrapper);
+    }
+
+    @Test
+    public void releaseProjectFromPipeline() throws Exception {
+        WorkflowJob us = j.jenkins.createProject(WorkflowJob.class, "us");
+        us.setDefinition(new CpsFlowDefinition(
+                "m2release job: 'ds', releaseVersion: '1.2.3', developmentVersion: '2.0.0', dryRun: true\n"
+                + " echo \"release's done\""
+                , true));
+        WorkflowRun workflowRun = j.buildAndAssertSuccess(us);
+        j.assertLogContains("its only a dryRun, no need to mark it for keep", ds.getBuildByNumber(1));
+        j.assertLogContains("-DreleaseVersion=1.2.3 ", ds.getBuildByNumber(1));
+        j.assertLogContains("-DdevelopmentVersion=2.0.0", ds.getBuildByNumber(1));
+
+        j.assertBuildStatusSuccess(ds.getBuildByNumber(1));
+        j.assertLogContains("release's done", workflowRun);
+    }
+
+    @Test
+    public void testDefaultParameters() throws Exception {
+        /* job should be built at least once to have modules initialized */
+        j.buildAndAssertSuccess(ds);
+        ds.getBuildByNumber(1).delete();
+
+        WorkflowJob us = j.jenkins.createProject(WorkflowJob.class, "us");
+        us.setDefinition(new CpsFlowDefinition(
+                "m2release job: 'ds', dryRun: true\n"
+                        + " echo \"release's done\""
+                , true));
+
+        WorkflowRun workflowRun = j.buildAndAssertSuccess(us);
+        j.assertLogContains("release's done", workflowRun);
+
+        j.assertLogContains("its only a dryRun, no need to mark it for keep", ds.getBuildByNumber(2));
+        j.assertLogContains("-DdevelopmentVersion=1.7-SNAPSHOT", ds.getBuildByNumber(2));
+        j.assertLogContains("-DreleaseVersion=1.6", ds.getBuildByNumber(2));
+    }
+}


### PR DESCRIPTION
Pipeline support is added to release plugin. Release can be triggered from pipeline as following:
`m2release job: 'jobname' `

I was using pipeline-build-step-plugin as a reference as well as release-plugin.

I've done few modifications in order to be able to start developing on the plugin (currently compilation is failing on master brunch): 

1. fixed javadoc errors 
2. junit tests updated to use `@Rules` instead of inheriting `HudsonTestCase`
3. missing header `<?jelly escape-by-default='true'?>` was added to  *.jelly files