### PR TITLE
Remove usages of Prototype

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 	<properties>
 		<revision>0.16.4</revision>
 		<changelist>-SNAPSHOT</changelist>
-		<jenkins.version>2.387.3</jenkins.version>
+		<jenkins.version>2.410</jenkins.version>
 		<gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
 	</properties>
 
@@ -58,7 +58,7 @@
 		<dependencies>
 			<dependency>
 				<groupId>io.jenkins.tools.bom</groupId>
-				<artifactId>bom-2.387.x</artifactId>
+				<artifactId>bom-2.401.x</artifactId>
 				<version>2244.vd60654536b_96</version>
 				<type>pom</type>
 				<scope>import</scope>

--- a/src/main/resources/org/jvnet/hudson/plugins/m2release/M2ReleaseBuildWrapper/global.jelly
+++ b/src/main/resources/org/jvnet/hudson/plugins/m2release/M2ReleaseBuildWrapper/global.jelly
@@ -22,15 +22,15 @@
 			<f:optionalBlock name="m2release.nexusSupport" title="Enable Nexus Pro support" checked="${descriptor.nexusSupport}" help="${rootURL}/plugin/m2release/help-globalConfig.html">
 				<f:entry title="Nexus URL" help="${rootURL}/plugin/m2release/help-nexusURL.html">
 					<f:textbox name="m2release.nexusURL" value="${descriptor.nexusURL}" 
-					           onchange="Form.findMatchingInput(this,'m2release.nexusPassword').onchange()" />
+					           onchange="findMatchingFormInput(this,'m2release.nexusPassword').onchange()" />
 				</f:entry>
 				<f:entry title="Nexus User" help="${rootURL}/plugin/m2release/help-nexusUserPass.html" >
 					<f:textbox name="m2release.nexusUser" value="${descriptor.nexusUser}" 
-					           onchange="Form.findMatchingInput(this,'m2release.nexusPassword').onchange()" />
+					           onchange="findMatchingFormInput(this,'m2release.nexusPassword').onchange()" />
 				</f:entry>
 				<f:entry title="Nexus Password" help="${rootURL}/plugin/m2release/help-nexusUserPass.html">
 					<f:password name="m2release.nexusPassword" value="${descriptor.nexusPassword}" 
-					            checkUrl="'${rootURL}/buildWrapper/M2ReleaseBuildWrapper/urlCheck?urlValue='+escape(Form.findMatchingInput(this,'m2release.nexusURL').value)+'&amp;usernameValue='+escape(Form.findMatchingInput(this,'m2release.nexusUser').value)+'&amp;passwordValue='+escape(Form.findMatchingInput(this,'m2release.nexusPassword').value)"
+					            checkUrl="'${rootURL}/buildWrapper/M2ReleaseBuildWrapper/urlCheck?urlValue='+escape(findMatchingFormInput(this,'m2release.nexusURL').value)+'&amp;usernameValue='+escape(findMatchingFormInput(this,'m2release.nexusUser').value)+'&amp;passwordValue='+escape(findMatchingFormInput(this,'m2release.nexusPassword').value)"
 					            checkMethod="post" />
 				</f:entry>
 			</f:optionalBlock>


### PR DESCRIPTION
Downstream of #43. Remove usages of Prototype in favor of the new API introduced in https://github.com/jenkinsci/jenkins/pull/8008 (2.406) and subsequently corrected in https://github.com/jenkinsci/jenkins/pull/8100 (2.410).