### PR TITLE
Revert "Bump org.apache.maven.release:maven-release-manager from 2.5.3 to 3.0.1"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
 		<dependency>
 			<groupId>org.apache.maven.release</groupId>
 			<artifactId>maven-release-manager</artifactId>
-			<version>3.0.1</version>
+			<version>2.5.3</version>
 				<!--  we only need 2 classes o.a.m.shared.release.versions.DefaultVersionInfo
 				      and o.a.m.shared.release.versions.VersionParseException
 				-->


### PR DESCRIPTION
Reverts jenkinsci/m2release-plugin#45

Does not properly take into account bundled dependencies