### PR TITLE
Require Jenkins 2.414.3 LTS or newer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 	<properties>
 		<revision>0.16.5</revision>
 		<changelist>-SNAPSHOT</changelist>
-		<jenkins.version>2.410</jenkins.version>
+		<jenkins.version>2.414.3</jenkins.version>
 		<gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
 	</properties>
 
@@ -58,7 +58,7 @@
 		<dependencies>
 			<dependency>
 				<groupId>io.jenkins.tools.bom</groupId>
-				<artifactId>bom-2.401.x</artifactId>
+				<artifactId>bom-2.414.x</artifactId>
 				<version>2675.v1515e14da_7a_6</version>
 				<type>pom</type>
 				<scope>import</scope>


### PR DESCRIPTION
Now that the baseline is available in LTS form, prefer it for the reasons given in [the documentation](https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/).