### PR TITLE
Migrate from com.github.tomakehurst to org.wiremock

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -221,9 +221,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.tomakehurst</groupId>
-            <artifactId>wiremock-jre8-standalone</artifactId>
-            <version>2.35.2</version>
+            <groupId>org.wiremock</groupId>
+            <artifactId>wiremock-standalone</artifactId>
+            <version>3.12.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
## Migrate from `com.github.tomakehurst` to `org.wiremock`

In 2023 [WireMock](https://wiremock.org) updated their `groupId` and `artifactId` with the most recent major release of WireMock 3.
See [the announcement](https://www.wiremock.io/post/wiremock-3-goes-ga) for more details on the topic.

This PR migrates the `groupId` and `artifactId` to the new coordinates and also updates to the latest version.
This change enables receiving further updates on the dependency (e.g. via dependabot or renovate).

### Testing done

None. Rely on `ci.jenkins.io` to test it.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
